### PR TITLE
Predict schema endpoint, feature-order enforcement, YAML OpenAPI + CI drift check Suggested PR body

### DIFF
--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -1,0 +1,29 @@
+name: openapi-drift-check
+on:
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install project
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          pip install -e .
+          pip install pyyaml
+      - name: Regenerate OpenAPI
+        run: |
+          . .venv/bin/activate
+          python scripts/export_openapi.py
+      - name: Check drift
+        run: |
+          git diff --exit-code docs/openapi.yaml || {
+            echo "::error::OpenAPI schema drift detected. Run: . .venv/bin/activate && python scripts/export_openapi.py and commit changes.";
+            exit 1;
+          }

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ audit.db
 .local/vectorstore/chroma.sqlite3
 data/vectorstore
 e2e_logs/
+docs/promote_repo.md
+ai_architect.egg-info/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11.9-slim-bookworm
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -8,10 +8,13 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 # Install build deps for some libs (pandas, scipy stack minimal)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    gcc \
-    curl \
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        gcc \
+        curl \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Create venv and install pip

--- a/app/routers/architect_stream.py
+++ b/app/routers/architect_stream.py
@@ -34,7 +34,17 @@ async def _gen_sse(plan: Dict[str, Any], audit: Dict[str, Any]) -> AsyncGenerato
     # Final audit
     yield f"event: audit\ndata: {json.dumps(audit)}\n\n".encode()
 
-@router.get("/architect/stream")
+@router.get(
+    "/architect/stream",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "content": {
+                "text/event-stream": {"schema": {"type": "string"}},
+            }
+        }
+    },
+)
 async def stream_architect(request: Request, question: str | None = None, session_id: str | None = None, user_id: str | None = None):
     # Defensive guard: no-op stream for empty/short questions
     q = (question or "").strip()

--- a/app/routers/pii.py
+++ b/app/routers/pii.py
@@ -40,7 +40,7 @@ def post_pii(req: Request, payload: PiiRequest):
 
     start = time.perf_counter()
     # Detect
-    result = detect_pii(payload.text)
+    result = detect_pii(payload.text, types=payload.types)
     if result.get("total", 0) > 0:
         parts = [f"{k}({v})" for k, v in sorted(result.get("counts", {}).items())]
         summary = ", ".join(parts)

--- a/app/routers/predict.py
+++ b/app/routers/predict.py
@@ -18,7 +18,7 @@ def get_predict_schema(role: str = Depends(require_role("analyst"))):
     """Return expected feature list and model metadata from latest run."""
     client = MLflowClientWrapper()
     try:
-        _model, run_id = client.load_latest_model()
+        _model, run_id, _model_uri = client.load_latest_model()
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"model load failed: {e}")
     features = client.get_feature_order(run_id=run_id) or []
@@ -38,7 +38,7 @@ def post_predict(
 
     client = MLflowClientWrapper()
     try:
-        model, run_id = client.load_latest_model()
+        model, run_id, model_uri = client.load_latest_model()
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"model load failed: {e}")
 
@@ -102,6 +102,7 @@ def post_predict(
         "response_hash": make_hash(str(pred)),
         "model_run_id": run_id,
         "model_experiment": client.get_experiment_name(),
+        "model_uri": model_uri,
     }
 
     try:

--- a/app/routers/query.py
+++ b/app/routers/query.py
@@ -439,9 +439,10 @@ def post_query(req: Request, payload: QueryRequest):
         except Exception:
             pass
     try:
-        from app.services.router import get_backend_meta
+        # Reflect actual router mode in audit: rules_v2 when enabled, simple when disabled
+        from app.services import router as _router_svc
 
-        audit.router_backend = get_backend_meta()
+        audit.router_backend = _router_svc.get_backend_meta() if _router_svc.is_enabled() else "simple"
         audit.router_intent = intent
         audit_dict["router_backend"] = audit.router_backend
         audit_dict["router_intent"] = audit.router_intent

--- a/app/services/mlflow_client.py
+++ b/app/services/mlflow_client.py
@@ -33,13 +33,70 @@ class MLflowClientWrapper:
             raise RuntimeError("No runs found in MLflow experiment")
         return runs.iloc[0]["run_id"]
 
+    def _now(self) -> float:
+        import time
+        return time.time()
+
+    def _cache_ttl(self) -> float:
+        try:
+            return float(os.getenv("MLFLOW_MODEL_CACHE_TTL", "0") or 0.0)
+        except Exception:
+            return 0.0
+
+    _MODEL_CACHE: dict[str, tuple[object, float]] = {}
+
+    def _load_model_uri(self, uri: str):
+        ttl = self._cache_ttl()
+        if ttl > 0:
+            item = self._MODEL_CACHE.get(uri)
+            if item:
+                model, ts = item
+                if (self._now() - ts) <= ttl:
+                    return model
+        model = mlflow.sklearn.load_model(uri)
+        if ttl > 0:
+            self._MODEL_CACHE[uri] = (model, self._now())
+        return model
+
     def load_latest_model(self, artifact_path: str | None = None):
-        # Find latest run in experiment and load its model artifact
+        # Prefer explicit model URI override if provided
+        explicit_uri = os.getenv("MLFLOW_MODEL_URI")
+        if explicit_uri:
+            model = self._load_model_uri(explicit_uri)
+            # Try to parse run_id from runs:/ URIs for auditing when possible
+            run_id = None
+            try:
+                if explicit_uri.startswith("runs:/"):
+                    parts = explicit_uri.split("/")
+                    run_id = parts[1]  # runs:/{run_id}/...
+            except Exception:
+                run_id = None
+            return model, (run_id or "unknown"), explicit_uri
+        # Otherwise load latest run
         run_id = self._get_latest_run_id()
         apath = artifact_path or self.model_artifact
         uri = f"runs:/{run_id}/{apath}"
-        model = mlflow.sklearn.load_model(uri)
-        return model, run_id
+        model = self._load_model_uri(uri)
+        return model, run_id, uri
+
+    def get_signature_input_names(self, model_uri: str) -> Optional[List[str]]:
+        try:
+            from mlflow.models import get_model_info
+
+            info = get_model_info(model_uri)
+            sig = getattr(info, "signature", None)
+            if sig and getattr(sig, "inputs", None) is not None:
+                try:
+                    d = sig.inputs.to_dict()  # type: ignore[attr-defined]
+                    cols = d.get("inputs") or d.get("columns") or []
+                    names = [c.get("name") for c in cols if isinstance(c, dict) and c.get("name")]
+                    if names:
+                        return names
+                except Exception:
+                    pass
+        except Exception:
+            return None
+        return None
 
     def get_feature_order(self, run_id: Optional[str] = None) -> Optional[List[str]]:
         """Try to download feature_order.json from the given run and return the list."""

--- a/app/services/mlflow_client.py
+++ b/app/services/mlflow_client.py
@@ -1,4 +1,6 @@
 import os
+import json
+from typing import List, Optional
 
 import mlflow
 import mlflow.sklearn
@@ -12,11 +14,15 @@ class MLflowClientWrapper:
         self.experiment = experiment or os.getenv(
             "MLFLOW_EXPERIMENT_NAME", "ai-architect"
         )
+        # Configurable artifact names with sensible defaults
+        self.model_artifact = os.getenv("MLFLOW_MODEL_ARTIFACT_PATH", "model")
+        self.feature_order_artifact = os.getenv(
+            "MLFLOW_FEATURE_ORDER_ARTIFACT", "feature_order.json"
+        )
         mlflow.set_tracking_uri(self.tracking_uri)
         mlflow.set_experiment(self.experiment)
 
-    def load_latest_model(self, artifact_path: str = "model"):
-        # Find latest run in experiment and load its model artifact
+    def _get_latest_run_id(self) -> str:
         exp = mlflow.get_experiment_by_name(self.experiment)
         if not exp:
             raise RuntimeError("MLflow experiment not found")
@@ -25,7 +31,33 @@ class MLflowClientWrapper:
         )
         if runs.empty:
             raise RuntimeError("No runs found in MLflow experiment")
-        run_id = runs.iloc[0]["run_id"]
-        uri = f"runs:/{run_id}/{artifact_path}"
+        return runs.iloc[0]["run_id"]
+
+    def load_latest_model(self, artifact_path: str | None = None):
+        # Find latest run in experiment and load its model artifact
+        run_id = self._get_latest_run_id()
+        apath = artifact_path or self.model_artifact
+        uri = f"runs:/{run_id}/{apath}"
         model = mlflow.sklearn.load_model(uri)
         return model, run_id
+
+    def get_feature_order(self, run_id: Optional[str] = None) -> Optional[List[str]]:
+        """Try to download feature_order.json from the given run and return the list."""
+        try:
+            rid = run_id or self._get_latest_run_id()
+            artifact_uri = f"runs:/{rid}/{self.feature_order_artifact}"
+            # mlflow 2.x
+            from mlflow.artifacts import download_artifacts  # lazy import
+
+            local_path = download_artifacts(artifact_uri)
+            with open(local_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            fo = data.get("feature_order")
+            if isinstance(fo, list) and all(isinstance(x, str) for x in fo):
+                return fo
+        except Exception:
+            return None
+        return None
+
+    def get_experiment_name(self) -> str:
+        return self.experiment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   api:
     build:

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -5,6 +5,23 @@ Architect agent and community loop
 - Users can copy the proposal (summary, steps, flags) into a GitHub issue; see docs/llm_agent_streaming_prompts.md for a ready-to-use prompt set.
 - This closes the loop between learning, brainstorming, and contribution, keeping the repo a living reference architecture.
 
+## Research Agent
+
+- Endpoint: POST /research (analyst/admin; per-step RBAC applies)
+- Steps:
+  1) search(topic) -> [{title, url}]
+  2) fetch(urls) -> [{url, text}]
+  3) summarize(docs) -> findings: [{title, summary, url}]
+  4) risk_check(topic, findings) -> flagged: bool (uses DENYLIST)
+- Config:
+  - AGENT_LIVE_MODE (default: false) — when true, fetch performs real HTTP GETs (limited)
+  - AGENT_URL_ALLOWLIST (comma-separated prefixes) — restricts live fetch to allowed domains/prefixes
+  - DENYLIST (comma-separated terms) — flags risky research content in risk_check
+- RBAC:
+  - fetch/search/summarize: analyst+
+  - risk_check: guest+
+- Audit: steps include {name, inputs, outputs.preview, latency_ms, hash, timestamp}
+
 ## Policy Navigator Agent
 
 - Endpoint: POST /policy_navigator (analyst/admin)

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -34,6 +34,33 @@ Architect agent and community loop
   - POLICY_NAV_MAX_SUBQS (default: 3)
 - Audit: includes step entries for decompose, retrieve, synthesize with inputs/outputs preview and latency
 
+## Architect Agent
+
+- Endpoints:
+  - POST /architect — returns an ArchitectResponse with answer, citations (when grounded), suggested_steps, suggested_env_flags, and audit
+  - GET /architect/stream — Server-Sent Events (SSE) stream for progressive updates
+  - GET /architect/ui — HTML chat UI
+- Flags:
+  - PROJECT_GUIDE_ENABLED (default: false) — enables /architect API; UI shows a badge when disabled
+  - LLM_ENABLE_ARCHITECT (default: false) — when true, uses LLM-backed agent for plan generation
+  - DOCS_PATH — path to docs corpus for grounding; RAG flags apply
+  - RAG_MULTI_QUERY_ENABLED, RAG_MULTI_QUERY_COUNT, RAG_HYDE_ENABLED — retrieval behavior
+- SSE event contract (/architect/stream):
+  - event: meta
+    data: { "provider": string|null, "model": string|null, "grounded_used": bool|null }
+  - event: summary
+    data: string — a human-readable summary; may occur once
+  - event: steps
+    data: [string] — suggested steps (optional)
+  - event: flags
+    data: [string] — suggested env flags (optional)
+  - event: citations
+    data: [ { source: string, page?: number|null, snippet?: string|null } ] (optional)
+  - event: feature
+    data: { title?: string, summary?: string, steps?: [string], flags?: [string], citations?: [...] } (optional CTA)
+  - event: audit
+    data: { ... } — final audit metadata (tokens/cost if LLM used, rag flags, grounded_used, etc.)
+
 ## PII Remediation Agent
 
 - Endpoint: POST /pii_remediation (analyst/admin)

--- a/docs/api.md
+++ b/docs/api.md
@@ -52,6 +52,10 @@ This service is a FastAPI application for AI risk, compliance, and observability
 - GET /healthz — liveness probe
 - GET /metrics — Prometheus metrics (optionally token-protected)
 - POST /predict — model inference; requires role analyst/admin
+  - Request: { features: object, user_id?: string }
+  - Rules: features must be a non-empty object with numeric-like values
+  - Errors: 400 when features invalid or when no model is available (latest run not found)
+  - Notes: training is required first (see docs/ml.md)
 - POST /query
 
 Request: { question: str, grounded?: bool, user_id?: str, session_id?: str, intent?: str }

--- a/docs/api.md
+++ b/docs/api.md
@@ -59,9 +59,17 @@ Request: { question: str, grounded?: bool, user_id?: str, session_id?: str, inte
   - Notes: session_id enables short-term memory grouping when MEMORY_SHORT_ENABLED=true
   - Config: ROUTER_ENABLED (intent routing)
 - POST /risk — Risk scoring endpoint (analyst/admin)
-  - Request: { text: str }
-  - Response: { label, value, rationale, audit }
-- POST /policy_navigator — Policy Navigator Agent (analyst/admin)
+  - Request: { text: string }
+  - Response: { label: "low|medium|high", value: number in [0,1], rationale: string, audit: { ... } }
+  - Feature flags:
+    - RISK_ML_ENABLED (default: false) — when true, uses a deterministic pseudo-ML path
+    - RISK_THRESHOLD (default: 0.6) — classification threshold for ML path
+  - Behavior:
+    - Default is heuristic scoring based on risk keywords; audit.risk_score_method == "heuristic"
+    - When ML is enabled, audit.risk_score_method == "ml" and label/value are derived from the pseudo-ML signal
+  - Audit enrichment:
+    - audit.risk_score_label, audit.risk_score_value, audit.risk_score_method
+- POST /policy_navigator — Policy Navigator Agent (analyst/admin) — Policy Navigator Agent (analyst/admin)
   - Request: { question: string, max_subqs?: number }
   - Response: { recommendation: string, citations: [{source, snippet, page?}], audit: { steps[] } }
 - POST /pii_remediation — PII Remediation Agent (analyst/admin)

--- a/docs/api.md
+++ b/docs/api.md
@@ -110,6 +110,11 @@ Request: { question: str, grounded?: bool, user_id?: str, session_id?: str, inte
     - user_id: optional string
     - intent: optional ("auto"|"qa"|"pii_detect"|"risk_score"|"other"); default "auto"
 - POST /research — multi-step research pipeline with auditing; step RBAC applies
+  - Request: { topic: string, steps?: ["search","fetch","summarize","risk_check"], user_id?: string }
+  - Response: { findings: [...], sources: [...], steps: [{name,inputs,outputs,latency_ms,hash,timestamp}], audit: {...} }
+  - Defaults: steps defaults to [search, fetch, summarize, risk_check]
+  - Flags: AGENT_LIVE_MODE, AGENT_URL_ALLOWLIST, DENYLIST
+  - See docs/agents.md for step details
 
 ## Router Agent
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -126,5 +126,16 @@ Request: { question: str, grounded?: bool, user_id?: str, session_id?: str, inte
 - Audit enrichment: router_backend and router_intent are included in the /query response audit field.
 - When intent=pii_detect, the answer summarizes detections and the audit includes pii_entities_count, pii_types, and pii_counts.
 
+## Architect
 
-See Swagger (/docs) for full request/response schemas and try-it-out.
+- POST /architect (requires PROJECT_GUIDE_ENABLED=true)
+  - Request: { question: string (min 3), grounded?: boolean|null, user_id?: string, session_id?: string }
+  - Response: { answer: string, citations?: [Citation], suggested_steps?: [string], suggested_env_flags?: [string], audit: {...}, suggest_feature?: bool, feature_request?: object }
+  - Flags: PROJECT_GUIDE_ENABLED, LLM_ENABLE_ARCHITECT, DOCS_PATH, RAG flags
+- GET /architect/stream (SSE)
+  - Content-Type: text/event-stream
+  - Event contract: see docs/agents.md (Architect Agent)
+- GET /architect/ui
+  - Content-Type: text/html
+
+See docs/agents.md for details on SSE events and flags.

--- a/docs/api.md
+++ b/docs/api.md
@@ -58,6 +58,7 @@ This service is a FastAPI application for AI risk, compliance, and observability
   - Notes: training is required first (see docs/ml.md); the server reorders inputs to the training feature order
 - GET /predict/schema — returns expected feature list and model metadata (analyst/admin)
   - Response: { features: [string], run_id: string, experiment: string }
+  - Notes: Artifacts names configurable via MLFLOW_MODEL_ARTIFACT_PATH and MLFLOW_FEATURE_ORDER_ARTIFACT; MLFLOW_MODEL_URI can override model selection; MLFLOW_MODEL_CACHE_TTL enables in-process caching.
 - POST /query
 
 Request: { question: str, grounded?: bool, user_id?: str, session_id?: str, intent?: str }

--- a/docs/api.md
+++ b/docs/api.md
@@ -53,9 +53,11 @@ This service is a FastAPI application for AI risk, compliance, and observability
 - GET /metrics — Prometheus metrics (optionally token-protected)
 - POST /predict — model inference; requires role analyst/admin
   - Request: { features: object, user_id?: string }
-  - Rules: features must be a non-empty object with numeric-like values
-  - Errors: 400 when features invalid or when no model is available (latest run not found)
-  - Notes: training is required first (see docs/ml.md)
+  - Rules: features must be a non-empty object with numeric-like values; exact feature set must match training
+  - Errors: 400 when features invalid/mismatch or when no model is available
+  - Notes: training is required first (see docs/ml.md); the server reorders inputs to the training feature order
+- GET /predict/schema — returns expected feature list and model metadata (analyst/admin)
+  - Response: { features: [string], run_id: string, experiment: string }
 - POST /query
 
 Request: { question: str, grounded?: bool, user_id?: str, session_id?: str, intent?: str }

--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -70,13 +70,11 @@ Recommendations (priority draft)
 Next steps checklist
 - [ ] Run full test suite and record baseline in this file.
 - [ ] Produce endpoint-by-endpoint delta table (docs vs code) with parameters/status codes.
-- [ ] Deeper review: memory persistence guarantees and pruning semantics; long-memory eviction correctness.
-- [ ] Deeper review: router rule precedence and default behavior; document examples.
-- [ ] Deeper review: MLflow integration and predictable local runs.
 
 Session log
 - Session 5: Router — audit.router_backend now reflects 'simple' when disabled; docs/tests updated.
 - Session 6: Risk — clarified flags (RISK_ML_ENABLED, RISK_THRESHOLD) and audit fields; tests green.
 - Session 7: Research — documented steps, flags (AGENT_LIVE_MODE, AGENT_URL_ALLOWLIST, DENYLIST), and per-step RBAC; added allowlist test; tests green.
 - Session 9: Architect — documented endpoints, flags, and SSE event contract; added runtime SSE test; tests green.
+- Session 10: ML/MLflow — logged model signature and feature order during training; added negative tests for /predict; docs clarified train→predict flow; tests green.
 - Session 8: Observability — documented middleware behavior and audit persistence, added test to ensure /metrics isn’t counted; metrics/logging/audit tests green.

--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -78,3 +78,4 @@ Session log
 - Session 5: Router — audit.router_backend now reflects 'simple' when disabled; docs/tests updated.
 - Session 6: Risk — clarified flags (RISK_ML_ENABLED, RISK_THRESHOLD) and audit fields; tests green.
 - Session 7: Research — documented steps, flags (AGENT_LIVE_MODE, AGENT_URL_ALLOWLIST, DENYLIST), and per-step RBAC; added allowlist test; tests green.
+- Session 8: Observability — documented middleware behavior and audit persistence, added test to ensure /metrics isn’t counted; metrics/logging/audit tests green.

--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -77,9 +77,4 @@ Next steps checklist
 Session log
 - Session 5: Router — audit.router_backend now reflects 'simple' when disabled; docs/tests updated.
 - Session 6: Risk — clarified flags (RISK_ML_ENABLED, RISK_THRESHOLD) and audit fields; tests green.
-
-Session log
-- Session 1: Baseline mapping; no code changes.
-- Session 2: API alignment — Fixed OpenAPI content types for /metrics and /architect/stream; added tests; docs updated.
-- Session 3: Memory — Verified retention, pruning counters, idempotent deletes; clarified docs; tests green.
-- Session 4: PII — Added request-level types override in /pii; updated docs; PII tests green.
+- Session 7: Research — documented steps, flags (AGENT_LIVE_MODE, AGENT_URL_ALLOWLIST, DENYLIST), and per-step RBAC; added allowlist test; tests green.

--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -49,11 +49,10 @@ Quality notes (initial scan)
 - Performance: synchronous CPU-bound work mostly light; RAG path uses filesystem scans; long operations (MLflow, vector ops) are not on request path except predict — acceptable for reference implementation.
 - Testing: extensive functional tests; includes router rules, RAG flags, metrics, PII, risk, memory, LLM audit, drift, MLflow train — strong coverage by behavior.
 
-Doc vs code drift (early findings)
-- Architect endpoints (/architect, /architect/stream, /architect/ui) exist and are tested but not present in docs/openapi.yaml — consider adding to docs (or explicitly marking as experimental).
-- scripts/ingest_docs.py is now a validation no-op (no vector store); docs mention LangChain mode and ingestion as optional — OK but clarify in docs that ingestion simply validates docs path in current version.
-- Some docs reference vector store specifics historically; current code paths rely on a lightweight filesystem scan in services/langchain_rag.py — consider updating docs/rag.md accordingly.
-- Metrics names in docs: app_requests_total, app_request_latency_seconds, app_tokens_total, app_cost_usd_total — match code — OK.
+Doc vs code drift (current)
+- Architect endpoints are present in OpenAPI; content types corrected (/metrics -> text/plain; /architect/stream -> text/event-stream).
+- RAG ingestion is a lightweight filesystem scan; docs updated accordingly in RAG section.
+- PII: Request-level types override supported via payload.types; locales via env.
 
 Security and privacy posture (initial)
 - PII: /pii and /pii_remediation enforce analyst/admin; pii_detector used with best-effort; audit includes counts and types — OK.
@@ -76,5 +75,7 @@ Next steps checklist
 - [ ] Deeper review: MLflow integration and predictable local runs.
 
 Session log
-- Created by: code review session 1
-- Date: PLACEHOLDER_DATE
+- Session 1: Baseline mapping; no code changes.
+- Session 2: API alignment — Fixed OpenAPI content types for /metrics and /architect/stream; added tests; docs updated.
+- Session 3: Memory — Verified retention, pruning counters, idempotent deletes; clarified docs; tests green.
+- Session 4: PII — Added request-level types override in /pii; updated docs; PII tests green.

--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -75,6 +75,10 @@ Next steps checklist
 - [ ] Deeper review: MLflow integration and predictable local runs.
 
 Session log
+- Session 5: Router — audit.router_backend now reflects 'simple' when disabled; docs/tests updated.
+- Session 6: Risk — clarified flags (RISK_ML_ENABLED, RISK_THRESHOLD) and audit fields; tests green.
+
+Session log
 - Session 1: Baseline mapping; no code changes.
 - Session 2: API alignment — Fixed OpenAPI content types for /metrics and /architect/stream; added tests; docs updated.
 - Session 3: Memory — Verified retention, pruning counters, idempotent deletes; clarified docs; tests green.

--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -4,6 +4,9 @@ Overview and scope
 - Purpose: Baseline review of code quality, structure, and doc-to-code alignment. No application code changes in this session.
 - Deliverables: This living report, a checklist index, and a baseline test run summary.
 
+Operational notes
+- Tests are run via shell with .venv activated: . .venv/bin/activate && pytest -q
+
 Repository map (high level)
 - FastAPI app: app/
   - Routers: app/routers/* (query, research, predict, pii, pii_remediation, risk, memory, metrics, architect, architect_stream, architect_ui, policy)
@@ -30,7 +33,7 @@ API and behavior alignment checklist (initial)
   - Memory endpoints (get/delete short, get/delete long, export/import, status): implemented — OK
   - POST /policy_navigator: implemented — OK
   - POST /pii_remediation: implemented — OK
-  - Architect/Architect UI/stream endpoints exist but are intentionally not exposed in openapi.yaml (consider documenting explicitly) — NOTE
+  - Architect/Architect UI/stream endpoints are now present in OpenAPI. Content types adjusted: /metrics -> text/plain; /architect/stream -> text/event-stream — UPDATED
 
 Cross-cutting behavior
 - Request ID middleware present; exceptions mapped to JSON via app/utils/exceptions.py — aligns with docs/api.md.
@@ -57,9 +60,7 @@ Security and privacy posture (initial)
 - RBAC: step-level checks for /research; grounded queries restricted — OK.
 - Retention: memory docs describe env knobs; endpoints expose status and export/import — OK.
 
-Testing baseline (to be filled after running pytest)
-- Command: . .venv/bin/activate && pytest -q
-- Result: TEST_RESULTS_PLACEHOLDER
+
 
 Recommendations (priority draft)
 - Add architect endpoints to OpenAPI/docs or explicitly mark as experimental in docs.

--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -78,4 +78,5 @@ Session log
 - Session 5: Router — audit.router_backend now reflects 'simple' when disabled; docs/tests updated.
 - Session 6: Risk — clarified flags (RISK_ML_ENABLED, RISK_THRESHOLD) and audit fields; tests green.
 - Session 7: Research — documented steps, flags (AGENT_LIVE_MODE, AGENT_URL_ALLOWLIST, DENYLIST), and per-step RBAC; added allowlist test; tests green.
+- Session 9: Architect — documented endpoints, flags, and SSE event contract; added runtime SSE test; tests green.
 - Session 8: Observability — documented middleware behavior and audit persistence, added test to ensure /metrics isn’t counted; metrics/logging/audit tests green.

--- a/docs/code_review_index.yaml
+++ b/docs/code_review_index.yaml
@@ -16,9 +16,7 @@ tasks:
   
   
   
-  - id: research_review
-    title: Research pipeline steps, RBAC, and audit fields
-    status: pending
+  
   - id: architect_review
     title: Architect endpoints (guide/stream/ui) and documentation gaps
     status: pending

--- a/docs/code_review_index.yaml
+++ b/docs/code_review_index.yaml
@@ -17,9 +17,7 @@ tasks:
   
   
   
-  - id: architect_review
-    title: Architect endpoints (guide/stream/ui) and documentation gaps
-    status: pending
+  
   
   - id: ml_mlflow_review
     title: ML training, drift detection, and predict endpoint

--- a/docs/code_review_index.yaml
+++ b/docs/code_review_index.yaml
@@ -19,9 +19,7 @@ tasks:
   
   
   
-  - id: ml_mlflow_review
-    title: ML training, drift detection, and predict endpoint
-    status: pending
+  
   - id: security_rbac_review
     title: RBAC consistency and security posture
     status: pending

--- a/docs/code_review_index.yaml
+++ b/docs/code_review_index.yaml
@@ -8,15 +8,15 @@ tasks:
     title: Run pytest baseline and record results
     status: pending
   
+  - id: api_alignment
+    title: API vs OpenAPI/docs alignment matrix
+    status: done
+  
   - id: router_review
     title: Router behavior, rules precedence, and docs alignment
     status: pending
-  - id: memory_review
-    title: Memory (short/long) behavior, pruning, and docs alignment
-    status: pending
-  - id: pii_review
-    title: PII detection/remediation endpoints and privacy posture
-    status: pending
+  
+  
   - id: risk_review
     title: Risk scoring endpoint behavior and docs alignment
     status: pending

--- a/docs/code_review_index.yaml
+++ b/docs/code_review_index.yaml
@@ -1,13 +1,13 @@
 # Code review progress index (resume-friendly)
 # Each task has a stable ID. Check off as we go across sessions.
+# Operational note: Always run tests with the venv activated via shell:
+#   . .venv/bin/activate && pytest -q
 
 tasks:
   - id: tests_baseline
     title: Run pytest baseline and record results
     status: pending
-  - id: api_alignment
-    title: API vs OpenAPI/docs alignment matrix
-    status: pending
+  
   - id: router_review
     title: Router behavior, rules precedence, and docs alignment
     status: pending

--- a/docs/code_review_index.yaml
+++ b/docs/code_review_index.yaml
@@ -12,14 +12,10 @@ tasks:
     title: API vs OpenAPI/docs alignment matrix
     status: done
   
-  - id: router_review
-    title: Router behavior, rules precedence, and docs alignment
-    status: pending
   
   
-  - id: risk_review
-    title: Risk scoring endpoint behavior and docs alignment
-    status: pending
+  
+  
   - id: research_review
     title: Research pipeline steps, RBAC, and audit fields
     status: pending

--- a/docs/code_review_index.yaml
+++ b/docs/code_review_index.yaml
@@ -20,9 +20,7 @@ tasks:
   - id: architect_review
     title: Architect endpoints (guide/stream/ui) and documentation gaps
     status: pending
-  - id: observability_review
-    title: Metrics, logging, and health checks
-    status: pending
+  
   - id: ml_mlflow_review
     title: ML training, drift detection, and predict endpoint
     status: pending

--- a/docs/components.md
+++ b/docs/components.md
@@ -3,8 +3,8 @@
 - app/routers/query.py: core /query with router integration and RAG wiring
 - app/services/langchain_rag.py: retrieval/citations and RAG flags propagation
 - app/services/router.py: rules v2 backend, ENV-configurable
-- app/routers/pii.py, app/services/pii.py: PII detection logic and endpoint
-- app/routers/risk.py, app/services/risk.py: Risk endpoint and heuristic scorer
+- app/routers/pii.py, app/services/pii_detector.py: PII detection logic and endpoint
+- app/routers/risk.py, app/services/risk_scorer.py: Risk endpoint and heuristic scorer
 - app/routers/research.py: Research agent endpoint
 - app/routers/memory_short.py, app/routers/memory_long.py: memory endpoints
 - app/utils/rbac.py: roles, grounded policy

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -50,6 +50,15 @@ Export/Import (long-term)
 Status endpoint (admin only)
 - GET /memory/status returns current config, a summary of short/long memory, cumulative pruning counters, and audit metadata
 
+Delete semantics and idempotency
+- DELETE /memory/short clears turns and summary for the given user_id+session_id. Returns cleared=true when the operation succeeds; safe to call repeatedly.
+- DELETE /memory/long clears all facts for the given user_id. When MEMORY_LONG_ENABLED=true, the endpoint returns cleared=true even if there was nothing to clear (idempotent semantics).
+
+Counters and pruning notes
+- memory_short_pruned and memory_long_pruned in endpoint audits reflect items pruned during that request only.
+- /memory/status aggregates cumulative pruning counters since process start: memory_short_pruned_total, memory_long_pruned_total.
+- Retention pruning occurs on reads; max facts/turns enforcement occurs on write or export as noted in code.
+
 Retention quick start
 - SHORT_MEMORY_RETENTION_DAYS=7; SHORT_MEMORY_MAX_TURNS_PER_SESSION=100
 - MEMORY_LONG_RETENTION_DAYS=180; MEMORY_LONG_MAX_FACTS=500

--- a/docs/ml.md
+++ b/docs/ml.md
@@ -8,7 +8,7 @@
 - Artifacts logged per run:
   - model (sklearn)
   - model signature (inferred via mlflow.models.signature.infer_signature)
-  - feature_order.json: { feature_order: [ ... ] }
+  - feature_order.json (configurable via MLFLOW_FEATURE_ORDER_ARTIFACT): { feature_order: [ ... ] }
 - Quick start (local):
   - . .venv/bin/activate
   - export MLFLOW_TRACKING_URI=.mlruns; export MLFLOW_EXPERIMENT_NAME=ai-architect

--- a/docs/ml.md
+++ b/docs/ml.md
@@ -5,7 +5,15 @@
 - MLflow env vars:
   - MLFLOW_TRACKING_URI
   - MLFLOW_EXPERIMENT_NAME
-- Tests run training via `sys.executable` to use the active venv.
+- Artifacts logged per run:
+  - model (sklearn)
+  - model signature (inferred via mlflow.models.signature.infer_signature)
+  - feature_order.json: { feature_order: [ ... ] }
+- Quick start (local):
+  - . .venv/bin/activate
+  - export MLFLOW_TRACKING_URI=.mlruns; export MLFLOW_EXPERIMENT_NAME=ai-architect
+  - python ml/train.py
+  - Then POST /predict with a features object containing exactly these columns.
 
 ## Drift (PSI)
 - Script: ml/drift.py

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -35,3 +35,9 @@ scrape_configs:
 ## Logging
 - JSON logs include: level, message, logger, request_id (if present), and exception info.
 - Set log level via LOG_LEVEL (default INFO).
+- Request middleware logs every request with event=request, method, path, status_code, request_id, latency_ms.
+- /metrics requests are excluded from request counters and latency histograms by middleware.
+
+## Audit
+- Audit writes are best-effort; failures are logged and do not fail the request path.
+- Fields persisted: request_id, endpoint, user_id, created_at, tokens_prompt, tokens_completion, cost_usd, latency_ms, compliance_flag, prompt_hash, response_hash.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -47,8 +47,10 @@
           "200": {
             "description": "Successful Response",
             "content": {
-              "application/json": {
-                "schema": {}
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
               }
             }
           },
@@ -730,8 +732,10 @@
           "200": {
             "description": "Successful Response",
             "content": {
-              "application/json": {
-                "schema": {}
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
               }
             }
           },

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,1827 +1,1162 @@
-{
-  "openapi": "3.1.0",
-  "info": {
-    "title": "AI Architect",
-    "version": "0.1.0"
-  },
-  "paths": {
-    "/healthz": {
-      "get": {
-        "summary": "Healthz",
-        "operationId": "healthz_healthz_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        }
-      }
-    },
-    "/metrics": {
-      "get": {
-        "summary": "Metrics",
-        "operationId": "metrics_metrics_get",
-        "parameters": [
-          {
-            "name": "X-Metrics-Token",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Metrics-Token"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/query": {
-      "post": {
-        "summary": "Post Query",
-        "operationId": "post_query_query_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/QueryRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/QueryResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/research": {
-      "post": {
-        "summary": "Post Research",
-        "operationId": "post_research_research_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ResearchRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ResearchResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/predict": {
-      "post": {
-        "summary": "Post Predict",
-        "operationId": "post_predict_predict_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PredictRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PredictResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pii": {
-      "post": {
-        "summary": "Post Pii",
-        "operationId": "post_pii_pii_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PiiRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PiiResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/risk": {
-      "post": {
-        "summary": "Post Risk",
-        "operationId": "post_risk_risk_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RiskRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RiskResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/memory/short": {
-      "get": {
-        "summary": "Get Short Memory",
-        "operationId": "get_short_memory_memory_short_get",
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "User Id"
-            }
-          },
-          {
-            "name": "session_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MemoryShortResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "summary": "Delete Short Memory",
-        "operationId": "delete_short_memory_memory_short_delete",
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "User Id"
-            }
-          },
-          {
-            "name": "session_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Delete Short Memory Memory Short Delete"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/memory/long": {
-      "get": {
-        "summary": "Get Long Memory",
-        "operationId": "get_long_memory_memory_long_get",
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "User Id"
-            }
-          },
-          {
-            "name": "q",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Q"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MemoryLongResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "summary": "Delete Long Memory",
-        "operationId": "delete_long_memory_memory_long_delete",
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "User Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Delete Long Memory Memory Long Delete"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/memory/status": {
-      "get": {
-        "summary": "Get Memory Status",
-        "operationId": "get_memory_status_memory_status_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "type": "object",
-                  "title": "Response Get Memory Status Memory Status Get"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/memory/long/export": {
-      "get": {
-        "summary": "Export Long Memory",
-        "operationId": "export_long_memory_memory_long_export_get",
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "User Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MemoryLongResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/memory/long/import": {
-      "post": {
-        "summary": "Import Long Memory",
-        "operationId": "import_long_memory_memory_long_import_post",
-        "parameters": [
-          {
-            "name": "user_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "User Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MemoryImportPayload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Import Long Memory Memory Long Import Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/policy_navigator": {
-      "post": {
-        "summary": "Post Policy Navigator",
-        "operationId": "post_policy_navigator_policy_navigator_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PolicyRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PolicyResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pii_remediation": {
-      "post": {
-        "summary": "Post Pii Remediation",
-        "operationId": "post_pii_remediation_pii_remediation_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PiiRemediationRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PiiRemediationResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/architect": {
-      "post": {
-        "tags": [
-          "Architect"
-        ],
-        "summary": "Post Architect",
-        "operationId": "post_architect_architect_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ArchitectRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ArchitectResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/architect/stream": {
-      "get": {
-        "summary": "Stream Architect",
-        "operationId": "stream_architect_architect_stream_get",
-        "parameters": [
-          {
-            "name": "question",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Question"
-            }
-          },
-          {
-            "name": "session_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Session Id"
-            }
-          },
-          {
-            "name": "user_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "User Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "text/event-stream": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/architect/ui": {
-      "get": {
-        "tags": [
-          "Architect"
-        ],
-        "summary": "Get Ui",
-        "operationId": "get_ui_architect_ui_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "text/html": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ui": {
-      "get": {
-        "tags": [
-          "UI"
-        ],
-        "summary": "Get Ui",
-        "operationId": "get_ui_ui_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "text/html": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ui/architect": {
-      "post": {
-        "tags": [
-          "UI"
-        ],
-        "summary": "Ui Architect",
-        "operationId": "ui_architect_ui_architect_post",
-        "requestBody": {
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_ui_architect_ui_architect_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "text/html": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ui/query": {
-      "post": {
-        "tags": [
-          "UI"
-        ],
-        "summary": "Ui Query",
-        "operationId": "ui_query_ui_query_post",
-        "requestBody": {
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_ui_query_ui_query_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "text/html": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ui/research": {
-      "post": {
-        "tags": [
-          "UI"
-        ],
-        "summary": "Ui Research",
-        "operationId": "ui_research_ui_research_post",
-        "requestBody": {
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_ui_research_ui_research_post"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "text/html": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "AgentStep": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "inputs": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Inputs"
-          },
-          "outputs": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Outputs"
-          },
-          "latency_ms": {
-            "type": "integer",
-            "title": "Latency Ms"
-          },
-          "hash": {
-            "type": "string",
-            "title": "Hash"
-          },
-          "timestamp": {
-            "type": "string",
-            "title": "Timestamp"
-          }
-        },
-        "type": "object",
-        "required": [
-          "name",
-          "inputs",
-          "outputs",
-          "latency_ms",
-          "hash",
-          "timestamp"
-        ],
-        "title": "AgentStep"
-      },
-      "ArchitectRequest": {
-        "properties": {
-          "question": {
-            "type": "string",
-            "minLength": 3,
-            "title": "Question"
-          },
-          "grounded": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Grounded",
-            "description": "force retrieval from docs; when None, decide dynamically"
-          },
-          "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User Id"
-          },
-          "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Session Id"
-          }
-        },
-        "type": "object",
-        "required": [
-          "question"
-        ],
-        "title": "ArchitectRequest"
-      },
-      "ArchitectResponse": {
-        "properties": {
-          "answer": {
-            "type": "string",
-            "title": "Answer"
-          },
-          "citations": {
-            "items": {
-              "$ref": "#/components/schemas/Citation"
-            },
-            "type": "array",
-            "title": "Citations",
-            "default": []
-          },
-          "suggested_steps": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Suggested Steps",
-            "default": []
-          },
-          "suggested_env_flags": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Suggested Env Flags",
-            "default": []
-          },
-          "audit": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Audit"
-          },
-          "suggest_feature": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Suggest Feature"
-          },
-          "feature_request": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Feature Request"
-          }
-        },
-        "type": "object",
-        "required": [
-          "answer",
-          "audit"
-        ],
-        "title": "ArchitectResponse"
-      },
-      "Body_ui_architect_ui_architect_post": {
-        "properties": {
-          "question": {
-            "type": "string",
-            "minLength": 3,
-            "title": "Question"
-          },
-          "mode": {
-            "type": "string",
-            "title": "Mode"
-          },
-          "grounded": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Grounded"
-          },
-          "role": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Role"
-          }
-        },
-        "type": "object",
-        "required": [
-          "question",
-          "mode"
-        ],
-        "title": "Body_ui_architect_ui_architect_post"
-      },
-      "Body_ui_query_ui_query_post": {
-        "properties": {
-          "question": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Question"
-          },
-          "grounded": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Grounded"
-          },
-          "role": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Role"
-          }
-        },
-        "type": "object",
-        "required": [
-          "question"
-        ],
-        "title": "Body_ui_query_ui_query_post"
-      },
-      "Body_ui_research_ui_research_post": {
-        "properties": {
-          "topic": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Topic"
-          },
-          "steps": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Steps",
-            "default": [
-              "search",
-              "fetch",
-              "summarize",
-              "risk_check"
-            ]
-          },
-          "role": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Role"
-          }
-        },
-        "type": "object",
-        "required": [
-          "topic"
-        ],
-        "title": "Body_ui_research_ui_research_post"
-      },
-      "Citation": {
-        "properties": {
-          "source": {
-            "type": "string",
-            "title": "Source"
-          },
-          "page": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Page"
-          },
-          "snippet": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Snippet"
-          }
-        },
-        "type": "object",
-        "required": [
-          "source"
-        ],
-        "title": "Citation"
-      },
-      "Finding": {
-        "properties": {
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "summary": {
-            "type": "string",
-            "title": "Summary"
-          },
-          "url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Url"
-          }
-        },
-        "type": "object",
-        "required": [
-          "title",
-          "summary"
-        ],
-        "title": "Finding"
-      },
-      "HTTPValidationError": {
-        "properties": {
-          "detail": {
-            "items": {
-              "$ref": "#/components/schemas/ValidationError"
-            },
-            "type": "array",
-            "title": "Detail"
-          }
-        },
-        "type": "object",
-        "title": "HTTPValidationError"
-      },
-      "MemoryImportPayload": {
-        "properties": {
-          "facts": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "type": "array",
-            "title": "Facts"
-          }
-        },
-        "type": "object",
-        "required": [
-          "facts"
-        ],
-        "title": "MemoryImportPayload"
-      },
-      "MemoryLongResponse": {
-        "properties": {
-          "facts": {
-            "items": {},
-            "type": "array",
-            "title": "Facts"
-          },
-          "audit": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Audit"
-          }
-        },
-        "type": "object",
-        "required": [
-          "facts",
-          "audit"
-        ],
-        "title": "MemoryLongResponse"
-      },
-      "MemoryShortResponse": {
-        "properties": {
-          "turns": {
-            "items": {},
-            "type": "array",
-            "title": "Turns"
-          },
-          "summary": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Summary"
-          },
-          "audit": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Audit"
-          }
-        },
-        "type": "object",
-        "required": [
-          "turns",
-          "audit"
-        ],
-        "title": "MemoryShortResponse"
-      },
-      "PiiRemediationRequest": {
-        "properties": {
-          "text": {
-            "type": "string",
-            "minLength": 3,
-            "title": "Text"
-          },
-          "return_snippets": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Return Snippets",
-            "default": true
-          },
-          "grounded": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Grounded",
-            "default": false
-          }
-        },
-        "type": "object",
-        "required": [
-          "text"
-        ],
-        "title": "PiiRemediationRequest"
-      },
-      "PiiRemediationResponse": {
-        "properties": {
-          "remediation": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "type": "array",
-            "title": "Remediation"
-          },
-          "citations": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "type": "array",
-            "title": "Citations",
-            "default": []
-          },
-          "audit": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Audit"
-          }
-        },
-        "type": "object",
-        "required": [
-          "remediation",
-          "audit"
-        ],
-        "title": "PiiRemediationResponse"
-      },
-      "PiiRequest": {
-        "properties": {
-          "text": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Text"
-          },
-          "types": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Types"
-          },
-          "grounded": {
-            "type": "boolean",
-            "title": "Grounded",
-            "default": false
-          }
-        },
-        "type": "object",
-        "required": [
-          "text"
-        ],
-        "title": "PiiRequest"
-      },
-      "PiiResponse": {
-        "properties": {
-          "summary": {
-            "type": "string",
-            "title": "Summary"
-          },
-          "entities": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "type": "array",
-            "title": "Entities"
-          },
-          "counts": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Counts"
-          },
-          "types_present": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Types Present"
-          },
-          "audit": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Audit"
-          }
-        },
-        "type": "object",
-        "required": [
-          "summary",
-          "entities",
-          "counts",
-          "types_present",
-          "audit"
-        ],
-        "title": "PiiResponse"
-      },
-      "PolicyRequest": {
-        "properties": {
-          "question": {
-            "type": "string",
-            "minLength": 3,
-            "title": "Question"
-          },
-          "max_subqs": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Max Subqs",
-            "description": "Override max sub-questions"
-          }
-        },
-        "type": "object",
-        "required": [
-          "question"
-        ],
-        "title": "PolicyRequest"
-      },
-      "PolicyResponse": {
-        "properties": {
-          "recommendation": {
-            "type": "string",
-            "title": "Recommendation"
-          },
-          "citations": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            "type": "array",
-            "title": "Citations"
-          },
-          "audit": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Audit"
-          }
-        },
-        "type": "object",
-        "required": [
-          "recommendation",
-          "citations",
-          "audit"
-        ],
-        "title": "PolicyResponse"
-      },
-      "PredictRequest": {
-        "properties": {
-          "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User Id"
-          },
-          "features": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Features"
-          }
-        },
-        "type": "object",
-        "required": [
-          "features"
-        ],
-        "title": "PredictRequest"
-      },
-      "PredictResponse": {
-        "properties": {
-          "prediction": {
-            "title": "Prediction"
-          },
-          "model_version": {
-            "type": "string",
-            "title": "Model Version"
-          },
-          "metrics": {
-            "additionalProperties": {
-              "type": "number"
-            },
-            "type": "object",
-            "title": "Metrics",
-            "default": {}
-          },
-          "audit": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Audit"
-          }
-        },
-        "type": "object",
-        "required": [
-          "prediction",
-          "model_version",
-          "audit"
-        ],
-        "title": "PredictResponse"
-      },
-      "QueryRequest": {
-        "properties": {
-          "question": {
-            "type": "string",
-            "minLength": 3,
-            "title": "Question"
-          },
-          "grounded": {
-            "type": "boolean",
-            "title": "Grounded",
-            "default": false
-          },
-          "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User Id"
-          },
-          "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Session Id"
-          },
-          "intent": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Intent",
-            "description": "auto|qa|pii_detect|risk_score|other",
-            "default": "auto"
-          }
-        },
-        "type": "object",
-        "required": [
-          "question"
-        ],
-        "title": "QueryRequest"
-      },
-      "QueryResponse": {
-        "properties": {
-          "answer": {
-            "type": "string",
-            "title": "Answer"
-          },
-          "citations": {
-            "items": {
-              "$ref": "#/components/schemas/Citation"
-            },
-            "type": "array",
-            "title": "Citations",
-            "default": []
-          },
-          "audit": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Audit"
-          }
-        },
-        "type": "object",
-        "required": [
-          "answer",
-          "audit"
-        ],
-        "title": "QueryResponse"
-      },
-      "ResearchRequest": {
-        "properties": {
-          "topic": {
-            "type": "string",
-            "minLength": 3,
-            "title": "Topic"
-          },
-          "steps": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Steps"
-          },
-          "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User Id"
-          }
-        },
-        "type": "object",
-        "required": [
-          "topic"
-        ],
-        "title": "ResearchRequest"
-      },
-      "ResearchResponse": {
-        "properties": {
-          "findings": {
-            "items": {
-              "$ref": "#/components/schemas/Finding"
-            },
-            "type": "array",
-            "title": "Findings"
-          },
-          "sources": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Sources"
-          },
-          "audit": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Audit"
-          },
-          "steps": {
-            "items": {
-              "$ref": "#/components/schemas/AgentStep"
-            },
-            "type": "array",
-            "title": "Steps"
-          }
-        },
-        "type": "object",
-        "required": [
-          "findings",
-          "sources",
-          "audit"
-        ],
-        "title": "ResearchResponse"
-      },
-      "RiskRequest": {
-        "properties": {
-          "text": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Text"
-          }
-        },
-        "type": "object",
-        "required": [
-          "text"
-        ],
-        "title": "RiskRequest"
-      },
-      "RiskResponse": {
-        "properties": {
-          "label": {
-            "type": "string",
-            "title": "Label"
-          },
-          "value": {
-            "type": "number",
-            "title": "Value"
-          },
-          "rationale": {
-            "type": "string",
-            "title": "Rationale"
-          },
-          "audit": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Audit"
-          }
-        },
-        "type": "object",
-        "required": [
-          "label",
-          "value",
-          "rationale",
-          "audit"
-        ],
-        "title": "RiskResponse"
-      },
-      "ValidationError": {
-        "properties": {
-          "loc": {
-            "items": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "integer"
-                }
-              ]
-            },
-            "type": "array",
-            "title": "Location"
-          },
-          "msg": {
-            "type": "string",
-            "title": "Message"
-          },
-          "type": {
-            "type": "string",
-            "title": "Error Type"
-          }
-        },
-        "type": "object",
-        "required": [
-          "loc",
-          "msg",
-          "type"
-        ],
-        "title": "ValidationError"
-      }
-    }
-  }
-}
+openapi: 3.1.0
+info:
+  title: AI Architect
+  version: 0.1.0
+paths:
+  /healthz:
+    get:
+      summary: Healthz
+      operationId: healthz_healthz_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+  /metrics:
+    get:
+      summary: Metrics
+      operationId: metrics_metrics_get
+      parameters:
+      - name: X-Metrics-Token
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Metrics-Token
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/plain:
+              schema:
+                type: string
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /query:
+    post:
+      summary: Post Query
+      operationId: post_query_query_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QueryRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /research:
+    post:
+      summary: Post Research
+      operationId: post_research_research_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResearchRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResearchResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /predict/schema:
+    get:
+      summary: Get Predict Schema
+      description: Return expected feature list and model metadata from latest run.
+      operationId: get_predict_schema_predict_schema_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Get Predict Schema Predict Schema Get
+  /predict:
+    post:
+      summary: Post Predict
+      operationId: post_predict_predict_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PredictRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PredictResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /pii:
+    post:
+      summary: Post Pii
+      operationId: post_pii_pii_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PiiRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PiiResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /risk:
+    post:
+      summary: Post Risk
+      operationId: post_risk_risk_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiskRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiskResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /memory/short:
+    get:
+      summary: Get Short Memory
+      operationId: get_short_memory_memory_short_get
+      parameters:
+      - name: user_id
+        in: query
+        required: true
+        schema:
+          type: string
+          title: User Id
+      - name: session_id
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Session Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MemoryShortResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      summary: Delete Short Memory
+      operationId: delete_short_memory_memory_short_delete
+      parameters:
+      - name: user_id
+        in: query
+        required: true
+        schema:
+          type: string
+          title: User Id
+      - name: session_id
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Session Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Delete Short Memory Memory Short Delete
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /memory/long:
+    get:
+      summary: Get Long Memory
+      operationId: get_long_memory_memory_long_get
+      parameters:
+      - name: user_id
+        in: query
+        required: true
+        schema:
+          type: string
+          title: User Id
+      - name: q
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Q
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MemoryLongResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      summary: Delete Long Memory
+      operationId: delete_long_memory_memory_long_delete
+      parameters:
+      - name: user_id
+        in: query
+        required: true
+        schema:
+          type: string
+          title: User Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Delete Long Memory Memory Long Delete
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /memory/status:
+    get:
+      summary: Get Memory Status
+      operationId: get_memory_status_memory_status_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Get Memory Status Memory Status Get
+  /memory/long/export:
+    get:
+      summary: Export Long Memory
+      operationId: export_long_memory_memory_long_export_get
+      parameters:
+      - name: user_id
+        in: query
+        required: true
+        schema:
+          type: string
+          title: User Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MemoryLongResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /memory/long/import:
+    post:
+      summary: Import Long Memory
+      operationId: import_long_memory_memory_long_import_post
+      parameters:
+      - name: user_id
+        in: query
+        required: true
+        schema:
+          type: string
+          title: User Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MemoryImportPayload'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Import Long Memory Memory Long Import Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /policy_navigator:
+    post:
+      summary: Post Policy Navigator
+      operationId: post_policy_navigator_policy_navigator_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /pii_remediation:
+    post:
+      summary: Post Pii Remediation
+      operationId: post_pii_remediation_pii_remediation_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PiiRemediationRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PiiRemediationResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /architect:
+    post:
+      tags:
+      - Architect
+      summary: Post Architect
+      operationId: post_architect_architect_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ArchitectRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArchitectResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /architect/stream:
+    get:
+      summary: Stream Architect
+      operationId: stream_architect_architect_stream_get
+      parameters:
+      - name: question
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Question
+      - name: session_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Session Id
+      - name: user_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: User Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /architect/ui:
+    get:
+      tags:
+      - Architect
+      summary: Get Ui
+      operationId: get_ui_architect_ui_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/html:
+              schema:
+                type: string
+  /ui:
+    get:
+      tags:
+      - UI
+      summary: Get Ui
+      operationId: get_ui_ui_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/html:
+              schema:
+                type: string
+  /ui/architect:
+    post:
+      tags:
+      - UI
+      summary: Ui Architect
+      operationId: ui_architect_ui_architect_post
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Body_ui_architect_ui_architect_post'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/html:
+              schema:
+                type: string
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /ui/query:
+    post:
+      tags:
+      - UI
+      summary: Ui Query
+      operationId: ui_query_ui_query_post
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Body_ui_query_ui_query_post'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/html:
+              schema:
+                type: string
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /ui/research:
+    post:
+      tags:
+      - UI
+      summary: Ui Research
+      operationId: ui_research_ui_research_post
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Body_ui_research_ui_research_post'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/html:
+              schema:
+                type: string
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+components:
+  schemas:
+    AgentStep:
+      properties:
+        name:
+          type: string
+          title: Name
+        inputs:
+          additionalProperties: true
+          type: object
+          title: Inputs
+        outputs:
+          additionalProperties: true
+          type: object
+          title: Outputs
+        latency_ms:
+          type: integer
+          title: Latency Ms
+        hash:
+          type: string
+          title: Hash
+        timestamp:
+          type: string
+          title: Timestamp
+      type: object
+      required:
+      - name
+      - inputs
+      - outputs
+      - latency_ms
+      - hash
+      - timestamp
+      title: AgentStep
+    ArchitectRequest:
+      properties:
+        question:
+          type: string
+          minLength: 3
+          title: Question
+        grounded:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Grounded
+          description: force retrieval from docs; when None, decide dynamically
+        user_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: User Id
+        session_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Session Id
+      type: object
+      required:
+      - question
+      title: ArchitectRequest
+    ArchitectResponse:
+      properties:
+        answer:
+          type: string
+          title: Answer
+        citations:
+          items:
+            $ref: '#/components/schemas/Citation'
+          type: array
+          title: Citations
+          default: []
+        suggested_steps:
+          items:
+            type: string
+          type: array
+          title: Suggested Steps
+          default: []
+        suggested_env_flags:
+          items:
+            type: string
+          type: array
+          title: Suggested Env Flags
+          default: []
+        audit:
+          additionalProperties: true
+          type: object
+          title: Audit
+        suggest_feature:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Suggest Feature
+        feature_request:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Feature Request
+      type: object
+      required:
+      - answer
+      - audit
+      title: ArchitectResponse
+    Body_ui_architect_ui_architect_post:
+      properties:
+        question:
+          type: string
+          minLength: 3
+          title: Question
+        mode:
+          type: string
+          title: Mode
+        grounded:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Grounded
+        role:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Role
+      type: object
+      required:
+      - question
+      - mode
+      title: Body_ui_architect_ui_architect_post
+    Body_ui_query_ui_query_post:
+      properties:
+        question:
+          type: string
+          minLength: 1
+          title: Question
+        grounded:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Grounded
+        role:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Role
+      type: object
+      required:
+      - question
+      title: Body_ui_query_ui_query_post
+    Body_ui_research_ui_research_post:
+      properties:
+        topic:
+          type: string
+          minLength: 1
+          title: Topic
+        steps:
+          items:
+            type: string
+          type: array
+          title: Steps
+          default:
+          - search
+          - fetch
+          - summarize
+          - risk_check
+        role:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Role
+      type: object
+      required:
+      - topic
+      title: Body_ui_research_ui_research_post
+    Citation:
+      properties:
+        source:
+          type: string
+          title: Source
+        page:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Page
+        snippet:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Snippet
+      type: object
+      required:
+      - source
+      title: Citation
+    Finding:
+      properties:
+        title:
+          type: string
+          title: Title
+        summary:
+          type: string
+          title: Summary
+        url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Url
+      type: object
+      required:
+      - title
+      - summary
+      title: Finding
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          type: array
+          title: Detail
+      type: object
+      title: HTTPValidationError
+    MemoryImportPayload:
+      properties:
+        facts:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Facts
+      type: object
+      required:
+      - facts
+      title: MemoryImportPayload
+    MemoryLongResponse:
+      properties:
+        facts:
+          items: {}
+          type: array
+          title: Facts
+        audit:
+          additionalProperties: true
+          type: object
+          title: Audit
+      type: object
+      required:
+      - facts
+      - audit
+      title: MemoryLongResponse
+    MemoryShortResponse:
+      properties:
+        turns:
+          items: {}
+          type: array
+          title: Turns
+        summary:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Summary
+        audit:
+          additionalProperties: true
+          type: object
+          title: Audit
+      type: object
+      required:
+      - turns
+      - audit
+      title: MemoryShortResponse
+    PiiRemediationRequest:
+      properties:
+        text:
+          type: string
+          minLength: 3
+          title: Text
+        return_snippets:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Return Snippets
+          default: true
+        grounded:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Grounded
+          default: false
+      type: object
+      required:
+      - text
+      title: PiiRemediationRequest
+    PiiRemediationResponse:
+      properties:
+        remediation:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Remediation
+        citations:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Citations
+          default: []
+        audit:
+          additionalProperties: true
+          type: object
+          title: Audit
+      type: object
+      required:
+      - remediation
+      - audit
+      title: PiiRemediationResponse
+    PiiRequest:
+      properties:
+        text:
+          type: string
+          minLength: 1
+          title: Text
+        types:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Types
+        grounded:
+          type: boolean
+          title: Grounded
+          default: false
+      type: object
+      required:
+      - text
+      title: PiiRequest
+    PiiResponse:
+      properties:
+        summary:
+          type: string
+          title: Summary
+        entities:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Entities
+        counts:
+          additionalProperties: true
+          type: object
+          title: Counts
+        types_present:
+          items:
+            type: string
+          type: array
+          title: Types Present
+        audit:
+          additionalProperties: true
+          type: object
+          title: Audit
+      type: object
+      required:
+      - summary
+      - entities
+      - counts
+      - types_present
+      - audit
+      title: PiiResponse
+    PolicyRequest:
+      properties:
+        question:
+          type: string
+          minLength: 3
+          title: Question
+        max_subqs:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Max Subqs
+          description: Override max sub-questions
+      type: object
+      required:
+      - question
+      title: PolicyRequest
+    PolicyResponse:
+      properties:
+        recommendation:
+          type: string
+          title: Recommendation
+        citations:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Citations
+        audit:
+          additionalProperties: true
+          type: object
+          title: Audit
+      type: object
+      required:
+      - recommendation
+      - citations
+      - audit
+      title: PolicyResponse
+    PredictRequest:
+      properties:
+        user_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: User Id
+        features:
+          additionalProperties: true
+          type: object
+          title: Features
+      type: object
+      required:
+      - features
+      title: PredictRequest
+    PredictResponse:
+      properties:
+        prediction:
+          title: Prediction
+        model_version:
+          type: string
+          title: Model Version
+        metrics:
+          additionalProperties:
+            type: number
+          type: object
+          title: Metrics
+          default: {}
+        audit:
+          additionalProperties: true
+          type: object
+          title: Audit
+      type: object
+      required:
+      - prediction
+      - model_version
+      - audit
+      title: PredictResponse
+    QueryRequest:
+      properties:
+        question:
+          type: string
+          minLength: 3
+          title: Question
+        grounded:
+          type: boolean
+          title: Grounded
+          default: false
+        user_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: User Id
+        session_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Session Id
+        intent:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Intent
+          description: auto|qa|pii_detect|risk_score|other
+          default: auto
+      type: object
+      required:
+      - question
+      title: QueryRequest
+    QueryResponse:
+      properties:
+        answer:
+          type: string
+          title: Answer
+        citations:
+          items:
+            $ref: '#/components/schemas/Citation'
+          type: array
+          title: Citations
+          default: []
+        audit:
+          additionalProperties: true
+          type: object
+          title: Audit
+      type: object
+      required:
+      - answer
+      - audit
+      title: QueryResponse
+    ResearchRequest:
+      properties:
+        topic:
+          type: string
+          minLength: 3
+          title: Topic
+        steps:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Steps
+        user_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: User Id
+      type: object
+      required:
+      - topic
+      title: ResearchRequest
+    ResearchResponse:
+      properties:
+        findings:
+          items:
+            $ref: '#/components/schemas/Finding'
+          type: array
+          title: Findings
+        sources:
+          items:
+            type: string
+          type: array
+          title: Sources
+        audit:
+          additionalProperties: true
+          type: object
+          title: Audit
+        steps:
+          items:
+            $ref: '#/components/schemas/AgentStep'
+          type: array
+          title: Steps
+      type: object
+      required:
+      - findings
+      - sources
+      - audit
+      title: ResearchResponse
+    RiskRequest:
+      properties:
+        text:
+          type: string
+          minLength: 1
+          title: Text
+      type: object
+      required:
+      - text
+      title: RiskRequest
+    RiskResponse:
+      properties:
+        label:
+          type: string
+          title: Label
+        value:
+          type: number
+          title: Value
+        rationale:
+          type: string
+          title: Rationale
+        audit:
+          additionalProperties: true
+          type: object
+          title: Audit
+      type: object
+      required:
+      - label
+      - value
+      - rationale
+      - audit
+      title: RiskResponse
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          type: array
+          title: Location
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+      type: object
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError

--- a/docs/pii.md
+++ b/docs/pii.md
@@ -7,6 +7,9 @@ Environment variables
   - Additional base types available: ipv6, iban, passport
 - PII_LOCALES: comma-separated locales to enable locale-specific patterns (e.g., US,UK,CA,DE)
 
+Request-level filtering
+- The /pii endpoint accepts an optional types array in the request body to override enabled base types for that request only (e.g., ["ssn"]). Locales remain configured via PII_LOCALES.
+
 Base patterns
 - email: standard username@domain.tld format
 - phone: E.164-like and common national formats, supporting separators and parentheses

--- a/docs/router.md
+++ b/docs/router.md
@@ -23,6 +23,7 @@ Behavior
 Intent names and aliases
 - Canonical intent names: qa, pii_detect, risk_score, policy_navigator, pii_remediation, other.
 - Alias: some tests/docs may use the shorthand policy_nav; the router emits policy_navigator in audit.router_intent.
+- When ROUTER_ENABLED=false, the builtin heuristics run and audit.router_backend is set to "simple".
 
 Try it
 - curl -X POST localhost:8000/query -H 'Content-Type: application/json' -d '{"question":"Email is bob@example.com","grounded": false}'

--- a/docs/router.md
+++ b/docs/router.md
@@ -20,6 +20,10 @@ Behavior
 - If no rules are configured or no rule matches, builtin heuristics apply (e.g., email/ssn/credit card → pii_detect; risk/severity → risk_score; policy/gdpr/hipaa/compliance → policy_navigator; otherwise qa).
 - If grounded=true, the router returns qa (RBAC still applies for grounded queries).
 
+Intent names and aliases
+- Canonical intent names: qa, pii_detect, risk_score, policy_navigator, pii_remediation, other.
+- Alias: some tests/docs may use the shorthand policy_nav; the router emits policy_navigator in audit.router_intent.
+
 Try it
 - curl -X POST localhost:8000/query -H 'Content-Type: application/json' -d '{"question":"Email is bob@example.com","grounded": false}'
 - Expected: audit.router_intent == "pii_detect"

--- a/docs/router_rules.md
+++ b/docs/router_rules.md
@@ -49,6 +49,10 @@ Behavior notes
   - policy_navigator for policy/regulation/gdpr/hipaa/compliance
   - Otherwise qa
 
+Intent names and aliases
+- Canonical: qa, pii_detect, risk_score, policy_navigator, pii_remediation, other.
+- Alias: some tests/docs may use the shorthand policy_nav; the router emits policy_navigator in audit.router_intent.
+
 Troubleshooting
 - Matching is case-insensitive substring-based; include stems for broader matches (e.g., "anonymiz" catches anonymize/anonymization).
 - Validate JSON: echo $ROUTER_RULES_JSON | python -m json.tool

--- a/docs/router_rules.md
+++ b/docs/router_rules.md
@@ -52,6 +52,7 @@ Behavior notes
 Intent names and aliases
 - Canonical: qa, pii_detect, risk_score, policy_navigator, pii_remediation, other.
 - Alias: some tests/docs may use the shorthand policy_nav; the router emits policy_navigator in audit.router_intent.
+- When ROUTER_ENABLED=false, builtin heuristics are used and audit.router_backend is "simple".
 
 Troubleshooting
 - Matching is case-insensitive substring-based; include stems for broader matches (e.g., "anonymiz" catches anonymize/anonymization).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ dependencies = [
   "pymupdf>=1.24.9",
   "mlflow>=2.15.0",
   "scikit-learn>=1.5.0",
-  "pandas>=2.2.0",
-  "jinja2>=3.1.4",
+  "pandas>=2.2.0",  "jinja2>=3.1.4",
+  "PyYAML>=6.0",
 ]
 
 

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -4,8 +4,16 @@ from pathlib import Path
 from app.main import app
 
 if __name__ == "__main__":
-    # Generate and save OpenAPI spec to docs/openapi.yaml (JSON->YAML not required; keep JSON or convert if needed)
+    # Generate and save OpenAPI spec to docs/openapi.yaml in YAML (fallback to JSON if PyYAML missing)
     spec = app.openapi()
     out = Path(__file__).resolve().parents[1] / "docs" / "openapi.yaml"
-    out.write_text(json.dumps(spec, indent=2))
-    print(f"Exported OpenAPI schema to {out}")
+    try:
+        import yaml  # type: ignore
+
+        text = yaml.safe_dump(spec, sort_keys=False, allow_unicode=True)
+        out.write_text(text)
+        print(f"Exported OpenAPI schema (YAML) to {out}")
+    except Exception:
+        # Minimal fallback to avoid blocking local runs without PyYAML
+        out.write_text(json.dumps(spec, indent=2))
+        print(f"Exported OpenAPI schema (JSON fallback) to {out}")

--- a/tests/test_architect_stream_sse_runtime.py
+++ b/tests/test_architect_stream_sse_runtime.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_architect_stream_sse_contract(monkeypatch):
+    monkeypatch.setenv("PROJECT_GUIDE_ENABLED", "true")
+    client = TestClient(app)
+
+    r = client.get("/architect/stream", params={"question": "how does the router work?"})
+    assert r.status_code == 200
+    assert r.headers.get("content-type", "").startswith("text/event-stream")
+    body = r.content.decode("utf-8", errors="ignore")
+    # Should emit at least meta and audit events
+    assert "event: meta" in body
+    assert "event: audit" in body

--- a/tests/test_metrics_excludes_self.py
+++ b/tests/test_metrics_excludes_self.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_metrics_endpoint_is_not_counted_in_request_counters():
+    client = TestClient(app)
+    # Trigger at least one non-metrics request to ensure counters exist
+    r = client.get("/healthz")
+    assert r.status_code == 200
+
+    # Scrape metrics (this should not increment app_requests_total for /metrics)
+    metrics_text = client.get("/metrics").text
+    lines = metrics_text.splitlines()
+
+    # Ensure no counter sample is emitted for /metrics endpoint
+    assert not any(
+        line.startswith('app_requests_total{endpoint="/metrics"') for line in lines
+    ), "app_requests_total should not include /metrics endpoint"

--- a/tests/test_openapi_content_types.py
+++ b/tests/test_openapi_content_types.py
@@ -1,0 +1,27 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_openapi_metrics_content_type_plain_text():
+    spec = app.openapi()
+    metrics = spec["paths"]["/metrics"]["get"]
+    content = metrics.get("responses", {}).get("200", {}).get("content", {})
+    # It should advertise text/plain
+    assert "text/plain" in content
+
+
+def test_openapi_architect_stream_sse_content_type():
+    spec = app.openapi()
+    stream = spec["paths"]["/architect/stream"]["get"]
+    content = stream.get("responses", {}).get("200", {}).get("content", {})
+    # It should advertise text/event-stream
+    assert "text/event-stream" in content
+
+
+def test_openapi_architect_ui_html_content_type():
+    spec = app.openapi()
+    ui = spec["paths"]["/architect/ui"]["get"]
+    content = ui.get("responses", {}).get("200", {}).get("content", {})
+    # It should advertise text/html
+    assert "text/html" in content

--- a/tests/test_pii_types_payload.py
+++ b/tests/test_pii_types_payload.py
@@ -1,0 +1,22 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_pii_types_payload_overrides_env(monkeypatch):
+    # Ensure env would enable email by default
+    monkeypatch.setenv("PII_TYPES", "email,ssn")
+    client = TestClient(app)
+    text = "email alice@example.com SSN 123-45-6789"
+
+    # Request-level override: only ssn
+    r = client.post(
+        "/pii",
+        json={"text": text, "types": ["ssn"]},
+        headers={"X-User-Role": "analyst"},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    # Email should be suppressed, SSN detected
+    assert data.get("counts", {}).get("email", 0) == 0
+    assert data.get("counts", {}).get("ssn", 0) >= 1

--- a/tests/test_predict_feature_enforcement.py
+++ b/tests/test_predict_feature_enforcement.py
@@ -1,0 +1,41 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def _train(monkeypatch, tmp_path):
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", str(tmp_path / ".mlruns"))
+    monkeypatch.setenv("MLFLOW_EXPERIMENT_NAME", "ai-architect-test")
+    import subprocess, sys
+    subprocess.check_call([sys.executable, "ml/train.py"])  # create run/model
+
+
+def test_predict_missing_feature(monkeypatch, tmp_path):
+    _train(monkeypatch, tmp_path)
+    client = TestClient(app)
+    # Omitting one feature from the expected set
+    payload = {"features": {"f0": 0.1, "f1": 0.2, "f2": 0.3}}
+    r = client.post("/predict", json=payload, headers={"X-User-Role": "analyst"})
+    assert r.status_code == 400
+    assert "missing features" in r.text
+
+
+def test_predict_extra_feature(monkeypatch, tmp_path):
+    _train(monkeypatch, tmp_path)
+    client = TestClient(app)
+    # Add an extra feature not present in training
+    payload = {"features": {"f0": 0.1, "f1": 0.2, "f2": 0.3, "f_extra": 1.0}}
+    r = client.post("/predict", json=payload, headers={"X-User-Role": "analyst"})
+    assert r.status_code == 400
+    assert "unknown features" in r.text
+
+
+def test_predict_shuffled_keys_ok(monkeypatch, tmp_path):
+    _train(monkeypatch, tmp_path)
+    client = TestClient(app)
+    # Correct set, shuffled order
+    payload = {"features": {"f3": 0.0, "f1": 0.2, "f0": 0.1, "f2": -0.1, "f4": 0.0, "f5": 0.0, "f6": 0.0, "f7": 0.1}}
+    r = client.post("/predict", json=payload, headers={"X-User-Role": "analyst"})
+    assert r.status_code == 200
+    data = r.json()
+    assert "prediction" in data

--- a/tests/test_predict_invalid_payload.py
+++ b/tests/test_predict_invalid_payload.py
@@ -1,0 +1,31 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_predict_rejects_empty_features(monkeypatch, tmp_path):
+    # Point to empty mlruns so model loading will fail later; we validate payload first
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", str(tmp_path / ".mlruns"))
+    monkeypatch.setenv("MLFLOW_EXPERIMENT_NAME", "ai-architect-test")
+    client = TestClient(app)
+
+    # Empty features object
+    r = client.post("/predict", json={"features": {}}, headers={"X-User-Role": "analyst"})
+    assert r.status_code == 400
+    assert "features must be a non-empty object" in r.text
+
+
+def test_predict_rejects_non_numeric_values(monkeypatch, tmp_path):
+    # Train a model to reach value validation (so model load passes)
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", str(tmp_path / ".mlruns"))
+    monkeypatch.setenv("MLFLOW_EXPERIMENT_NAME", "ai-architect-test")
+
+    import subprocess, sys
+
+    subprocess.check_call([sys.executable, "ml/train.py"])  # create run/model
+
+    client = TestClient(app)
+    bad_payload = {"features": {"f0": "oops", "f1": None}}
+    r = client.post("/predict", json=bad_payload, headers={"X-User-Role": "analyst"})
+    assert r.status_code == 400
+    assert "prediction failed" in r.text or "could not convert" in r.text

--- a/tests/test_predict_no_model.py
+++ b/tests/test_predict_no_model.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_predict_no_model_returns_400(monkeypatch, tmp_path):
+    # Fresh tracking dir and experiment name -> no runs available
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", str(tmp_path / ".mlruns"))
+    monkeypatch.setenv("MLFLOW_EXPERIMENT_NAME", "ai-architect-test")
+
+    client = TestClient(app)
+    payload = {"features": {"f0": 0.1, "f1": 0.2}}
+    r = client.post("/predict", json=payload, headers={"X-User-Role": "analyst"})
+    assert r.status_code == 400
+    assert "model load failed" in r.text.lower()

--- a/tests/test_predict_schema.py
+++ b/tests/test_predict_schema.py
@@ -1,0 +1,21 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_predict_schema_after_training(monkeypatch, tmp_path):
+    # Train a model to ensure schema exists
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", str(tmp_path / ".mlruns"))
+    monkeypatch.setenv("MLFLOW_EXPERIMENT_NAME", "ai-architect-test")
+
+    import subprocess, sys
+
+    subprocess.check_call([sys.executable, "ml/train.py"])  # create run/model
+
+    client = TestClient(app)
+    r = client.get("/predict/schema", headers={"X-User-Role": "analyst"})
+    assert r.status_code == 200
+    data = r.json()
+    assert isinstance(data.get("features", []), list)
+    assert data.get("run_id")
+    assert data.get("experiment")

--- a/tests/test_research_live_mode_allowlist.py
+++ b/tests/test_research_live_mode_allowlist.py
@@ -1,0 +1,32 @@
+import os
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_research_live_mode_respects_allowlist(monkeypatch):
+    # Enable live mode but restrict allowlist to a domain that does NOT match example.com
+    monkeypatch.setenv("AGENT_LIVE_MODE", "true")
+    monkeypatch.setenv("AGENT_URL_ALLOWLIST", "https://allowed.test")
+
+    client = TestClient(app)
+
+    r = client.post(
+        "/research",
+        json={
+            "topic": "network test",
+            "steps": ["search", "fetch"],
+        },
+        headers={"X-User-Role": "analyst"},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    # Find the fetch step and ensure count is 0 since allowlist doesn't match example.com
+    fetch_steps = [s for s in data.get("steps", []) if s.get("name") == "fetch"]
+    assert fetch_steps, "fetch step missing in audit steps"
+    out = fetch_steps[0].get("outputs", {})
+    # outputs.preview contains a string preview that includes count
+    # In our agent._audit_step we put outputs={"preview":str(outputs)[:200]} where outputs was {"count": len(contents)}
+    # So we validate that no contents were fetched
+    # If preview contains a dict-like string, simply check for 'count': 0 presence
+    assert "'count': 0" in out.get("preview", "") or out.get("preview", "").endswith("0}")

--- a/tests/test_risk_ml.py
+++ b/tests/test_risk_ml.py
@@ -4,7 +4,6 @@ from fastapi.testclient import TestClient
 from app.main import app
 
 
-@pytest.mark.skip(reason="ML path paused for launch; enabling later with MLflow integration")
 def test_risk_ml_enabled_changes_method_and_label(monkeypatch):
     monkeypatch.setenv("RISK_ML_ENABLED", "true")
     monkeypatch.setenv("RISK_THRESHOLD", "0.6")

--- a/tests/test_router_backend_disabled.py
+++ b/tests/test_router_backend_disabled.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_router_backend_marker_when_disabled(monkeypatch):
+    # Explicitly disable router
+    monkeypatch.setenv("ROUTER_ENABLED", "false")
+    client = TestClient(app)
+    r = client.post("/query", json={"question": "Hello", "grounded": False})
+    assert r.status_code == 200
+    aud = r.json().get("audit", {})
+    assert aud.get("router_backend") in (None, "simple")
+    assert aud.get("router_intent") in (None, "qa")


### PR DESCRIPTION
Add GET /predict/schema to expose expected feature list and model metadata.
Enforce training feature set and order in POST /predict using feature_order.json; robust numeric validation and clear 400 errors.
Export OpenAPI as YAML and add CI drift check workflow.